### PR TITLE
Remove Lock in Connection()

### DIFF
--- a/connection_producer.go
+++ b/connection_producer.go
@@ -72,6 +72,9 @@ func (c *mongoDBAtlasConnectionProducer) Close() error {
 }
 
 func (c *mongoDBAtlasConnectionProducer) Connection(_ context.Context) (interface{}, error) {
+	// This is intentionally not grabbing the lock since the calling functions (e.g. CreateUser)
+	// are claiming it. (The locking patterns could be refactored to be more consistent/clear.)
+
 	if !c.Initialized {
 		return nil, connutil.ErrNotInitialized
 	}


### PR DESCRIPTION
The lock is already held by the caller so having it here causes a deadlock.