### PR TITLE
Dial down the size of the creds producer constants

### DIFF
--- a/mongodbatlas.go
+++ b/mongodbatlas.go
@@ -35,7 +35,7 @@ func new() *MongoDBAtlas {
 	connProducer.Type = mongoDBAtlasTypeName
 
 	credsProducer := &credsutil.SQLCredentialsProducer{
-		DisplayNameLen: 0,
+		DisplayNameLen: credsutil.NoneLength,
 		RoleNameLen:    15,
 		UsernameLen:    20,
 		Separator:      "-",

--- a/mongodbatlas.go
+++ b/mongodbatlas.go
@@ -35,9 +35,9 @@ func new() *MongoDBAtlas {
 	connProducer.Type = mongoDBAtlasTypeName
 
 	credsProducer := &credsutil.SQLCredentialsProducer{
-		DisplayNameLen: 15,
+		DisplayNameLen: 0,
 		RoleNameLen:    15,
-		UsernameLen:    100,
+		UsernameLen:    20,
 		Separator:      "-",
 	}
 

--- a/mongodbatlas_test.go
+++ b/mongodbatlas_test.go
@@ -2,7 +2,6 @@ package mongodbatlas
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -114,8 +113,6 @@ func TestAcceptanceDatabaseUser_CreateUserWithSpecialChar(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-
-	fmt.Println(username)
 
 	if err := testCredsExists(projectID, publicKey, privateKey, username); err != nil {
 		t.Fatalf("Credentials were not created: %s", err)

--- a/mongodbatlas_test.go
+++ b/mongodbatlas_test.go
@@ -2,6 +2,7 @@ package mongodbatlas
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -68,6 +69,53 @@ func TestAcceptanceDatabaseUser_CreateUser(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+
+	if err := testCredsExists(projectID, publicKey, privateKey, username); err != nil {
+		t.Fatalf("Credentials were not created: %s", err)
+	}
+
+	if err := deleteCredentials(projectID, publicKey, privateKey, username); err != nil {
+		t.Fatalf("Credentials could not be deleted: %s", err)
+	}
+
+}
+
+func TestAcceptanceDatabaseUser_CreateUserWithSpecialChar(t *testing.T) {
+	if !runAcceptanceTests {
+		t.SkipNow()
+	}
+
+	publicKey := os.Getenv("ATLAS_PUBLIC_KEY")
+	privateKey := os.Getenv("ATLAS_PRIVATE_KEY")
+	projectID := os.Getenv("ATLAS_PROJECT_ID")
+
+	connectionDetails := map[string]interface{}{
+		"public_key":  publicKey,
+		"private_key": privateKey,
+		"project_id":  projectID,
+	}
+
+	db := new()
+	_, err := db.Init(context.Background(), connectionDetails, true)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	statements := dbplugin.Statements{
+		Creation: []string{testMongoDBAtlasRole},
+	}
+
+	usernameConfig := dbplugin.UsernameConfig{
+		DisplayName: "test.test",
+		RoleName:    "test",
+	}
+
+	username, _, err := db.CreateUser(context.Background(), statements, usernameConfig, time.Now().Add(time.Minute))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	fmt.Println(username)
 
 	if err := testCredsExists(projectID, publicKey, privateKey, username); err != nil {
 		t.Fatalf("Credentials were not created: %s", err)


### PR DESCRIPTION
# Overview
A high level description of the contribution, including:
Who the change affects or is for (stakeholders)?
Plugin users
What is the change? 
Make smaller the constants for the generation of usernames

Why is the change needed?
DisplayNames can contain characters that are not allowed on MongoDB Atlas API
How does this change affect the user experience (if at all)?

# Design of Change
How was this change implemented?

# Related Issues/Pull Requests
[Issue #7](https://github.com/hashicorp/vault-plugin-database-mongodbatlas/issues/7)

