### PR TITLE
go-client-mongodb-atlas v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/hashicorp/vault/api v1.0.5-0.20200215224050-f6547fa8e820
 	github.com/hashicorp/vault/sdk v0.1.14-0.20200215224050-f6547fa8e820
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
-	github.com/mitchellh/mapstructure v1.1.2
-	github.com/mongodb/go-client-mongodb-atlas v0.1.2
+	github.com/mitchellh/mapstructure v1.3.1
+	github.com/mongodb/go-client-mongodb-atlas v0.2.0
 	golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f // indirect
 	golang.org/x/text v0.3.2 // indirect
 	google.golang.org/genproto v0.0.0-20190801165951-fa694d86fc64 // indirect

--- a/go.sum
+++ b/go.sum
@@ -103,9 +103,11 @@ github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eI
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mitchellh/mapstructure v1.3.1 h1:cCBH2gTD2K0OtLlv/Y5H01VQCqmlDxz30kS5Y5bqfLA=
+github.com/mitchellh/mapstructure v1.3.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/mongodb/go-client-mongodb-atlas v0.1.2 h1:qmUme1TlQBPZupmXMnpD8DxnfGXLVGs3w+0Z17HBiSA=
-github.com/mongodb/go-client-mongodb-atlas v0.1.2/go.mod h1:LS8O0YLkA+sbtOb3fZLF10yY3tJM+1xATXMJ3oU35LU=
+github.com/mongodb/go-client-mongodb-atlas v0.2.0 h1:UH02byrzAlboirAMgV0sMIJqXbEfmGXIBa5IniwUZNI=
+github.com/mongodb/go-client-mongodb-atlas v0.2.0/go.mod h1:LS8O0YLkA+sbtOb3fZLF10yY3tJM+1xATXMJ3oU35LU=
 github.com/mwielbut/pointy v1.1.0 h1:U5/YEfoIkaGCHv0St3CgjduqXID4FNRoyZgLM1kY9vg=
 github.com/mwielbut/pointy v1.1.0/go.mod h1:MvvO+uMFj9T5DMda33HlvogsFBX7pWWKAkFIn4teYwY=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=

--- a/mongodbatlas.go
+++ b/mongodbatlas.go
@@ -134,7 +134,7 @@ func (m *MongoDBAtlas) RevokeUser(ctx context.Context, statements dbplugin.State
 		return err
 	}
 
-	_, err = client.DatabaseUsers.Delete(ctx, m.ProjectID, username)
+	_, err = client.DatabaseUsers.Delete(ctx, "admin", m.ProjectID, username)
 	return err
 }
 

--- a/mongodbatlas_test.go
+++ b/mongodbatlas_test.go
@@ -263,7 +263,7 @@ func testCredsExists(projectID, publicKey, privateKey, username string) (err err
 		return
 	}
 
-	_, _, err = client.DatabaseUsers.Get(context.Background(), projectID, username)
+	_, _, err = client.DatabaseUsers.Get(context.Background(), "admin", projectID, username)
 
 	return
 }
@@ -273,7 +273,7 @@ func deleteCredentials(projectID, publicKey, privateKey, username string) error 
 	if err != nil {
 		return err
 	}
-	_, err = client.DatabaseUsers.Delete(context.Background(), projectID, username)
+	_, err = client.DatabaseUsers.Delete(context.Background(), "admin", projectID, username)
 
 	return err
 }


### PR DESCRIPTION
# Overview

One of the underlying dependency has changed name, hence `go mod` is confused. As the dependency got updated, they added a new field, which looks to be `admin` by default.

- https://github.com/mongodb/go-client-mongodb-atlas/pull/89
- https://github.com/mongodb/go-client-mongodb-atlas/pull/49

# Contributor Checklist
- [x] No documentation changes
- [ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [x] Backwards compatible
