### PR TITLE
Backport 1.4.3: Creation statements aren't available in SetCredentials so don't require them

### DIFF
--- a/mongodbatlas.go
+++ b/mongodbatlas.go
@@ -149,12 +149,6 @@ func (m *MongoDBAtlas) SetCredentials(ctx context.Context, statements dbplugin.S
 	m.Lock()
 	defer m.Unlock()
 
-	statements = dbutil.StatementCompatibilityHelper(statements)
-
-	if len(statements.Creation) == 0 {
-		return "", "", dbutil.ErrEmptyCreationStatement
-	}
-
 	client, err := m.getConnection(ctx)
 	if err != nil {
 		return "", "", err


### PR DESCRIPTION
This PR backports a bug fix from https://github.com/hashicorp/vault-plugin-database-mongodbatlas/pull/11.