### PR TITLE
MongoDB Atlas - Add username customization

### DIFF
--- a/connection_producer.go
+++ b/connection_producer.go
@@ -2,11 +2,14 @@ package mongodbatlas
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/Sectorbob/mlab-ns2/gae/ns/digest"
+	dbplugin "github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 	"github.com/hashicorp/vault/sdk/database/helper/connutil"
 	"github.com/hashicorp/vault/sdk/helper/useragent"
+	"github.com/mitchellh/mapstructure"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -65,4 +68,30 @@ func (c *mongoDBAtlasConnectionProducer) Connection(_ context.Context) (interfac
 	c.client = client
 
 	return c.client, nil
+}
+
+func (m *mongoDBAtlasConnectionProducer) Initialize(ctx context.Context, req dbplugin.InitializeRequest) error {
+	m.Lock()
+	defer m.Unlock()
+
+	m.RawConfig = req.Config
+
+	err := mapstructure.WeakDecode(req.Config, m)
+	if err != nil {
+		return err
+	}
+
+	if len(m.PublicKey) == 0 {
+		return errors.New("public Key is not set")
+	}
+
+	if len(m.PrivateKey) == 0 {
+		return errors.New("private Key is not set")
+	}
+
+	// Set initialized to true at this point since all fields are set,
+	// and the connection can be established at a later time.
+	m.Initialized = true
+
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/Sectorbob/mlab-ns2 v0.0.0-20171030222938-d3aa0c295a8a
 	github.com/hashicorp/go-hclog v0.14.1
-	github.com/hashicorp/vault/sdk v0.1.14-0.20201022214319-d87657199d4b
+	github.com/hashicorp/vault/sdk v0.2.0
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
 	github.com/mitchellh/mapstructure v1.3.2
 	go.mongodb.org/atlas v0.7.1

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/hashicorp/vault/sdk v0.2.0
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
 	github.com/mitchellh/mapstructure v1.3.2
+	github.com/stretchr/testify v1.6.1 // indirect
 	go.mongodb.org/atlas v0.7.1
 	go.mongodb.org/mongo-driver v1.4.2
 )

--- a/go.sum
+++ b/go.sum
@@ -190,6 +190,8 @@ github.com/hashicorp/vault/api v1.0.5-0.20200519221902-385fac77e20f/go.mod h1:eu
 github.com/hashicorp/vault/sdk v0.1.14-0.20200519221530-14615acda45f/go.mod h1:WX57W2PwkrOPQ6rVQk+dy5/htHIaB4aBM70EwKThu10=
 github.com/hashicorp/vault/sdk v0.1.14-0.20201022214319-d87657199d4b h1:kT0HPwthAisVgxAkm/kNGI2IHm0rAco28dOs3geL90E=
 github.com/hashicorp/vault/sdk v0.1.14-0.20201022214319-d87657199d4b/go.mod h1:cAGI4nVnEfAyMeqt9oB+Mase8DNn3qA/LDNHURiwssY=
+github.com/hashicorp/vault/sdk v0.2.0 h1:hvVswvMA9LvXwLBFDJLIoDBXi8hj90Q+gSS7vRYmLvQ=
+github.com/hashicorp/vault/sdk v0.2.0/go.mod h1:cAGI4nVnEfAyMeqt9oB+Mase8DNn3qA/LDNHURiwssY=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=

--- a/mongodbatlas.go
+++ b/mongodbatlas.go
@@ -3,23 +3,28 @@ package mongodbatlas
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	dbplugin "github.com/hashicorp/vault/sdk/database/dbplugin/v5"
-	"github.com/hashicorp/vault/sdk/database/helper/credsutil"
 	"github.com/hashicorp/vault/sdk/database/helper/dbutil"
-	"github.com/mitchellh/mapstructure"
+	"github.com/hashicorp/vault/sdk/helper/strutil"
+	"github.com/hashicorp/vault/sdk/helper/template"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 
-const mongoDBAtlasTypeName = "mongodbatlas"
+const (
+	mongoDBAtlasTypeName = "mongodbatlas"
+
+	defaultUserNameTemplate = `{{ printf "v-%s-%s" (.RoleName | truncate 15) (random 20) | truncate 20 }}`
+)
 
 // Verify interface is implemented
 var _ dbplugin.Database = (*MongoDBAtlas)(nil)
 
 type MongoDBAtlas struct {
 	*mongoDBAtlasConnectionProducer
+
+	usernameProducer template.StringTemplate
 }
 
 func New() (interface{}, error) {
@@ -39,32 +44,33 @@ func new() *MongoDBAtlas {
 }
 
 func (m *MongoDBAtlas) Initialize(ctx context.Context, req dbplugin.InitializeRequest) (dbplugin.InitializeResponse, error) {
-	m.Lock()
-	defer m.Unlock()
-
-	m.RawConfig = req.Config
-
-	err := mapstructure.WeakDecode(req.Config, m.mongoDBAtlasConnectionProducer)
+	usernameTemplate, err := strutil.GetString(req.Config, "username_template")
 	if err != nil {
-		return dbplugin.InitializeResponse{}, err
+		return dbplugin.InitializeResponse{}, fmt.Errorf("failed to retrieve username_template: %w", err)
+	}
+	if usernameTemplate == "" {
+		usernameTemplate = defaultUserNameTemplate
 	}
 
-	if len(m.PublicKey) == 0 {
-		return dbplugin.InitializeResponse{}, errors.New("public Key is not set")
+	up, err := template.NewTemplate(template.Template(usernameTemplate))
+	if err != nil {
+		return dbplugin.InitializeResponse{}, fmt.Errorf("unable to initialize username template: %w", err)
+	}
+	m.usernameProducer = up
+
+	_, err = m.usernameProducer.Generate(dbplugin.UsernameMetadata{})
+	if err != nil {
+		return dbplugin.InitializeResponse{}, fmt.Errorf("invalid username template: %w", err)
 	}
 
-	if len(m.PrivateKey) == 0 {
-		return dbplugin.InitializeResponse{}, errors.New("private Key is not set")
+	err = m.mongoDBAtlasConnectionProducer.Initialize(ctx, req)
+	if err != nil {
+		return dbplugin.InitializeResponse{}, fmt.Errorf("failed to initialize: %w", err)
 	}
-
-	// Set initialized to true at this point since all fields are set,
-	// and the connection can be established at a later time.
-	m.Initialized = true
 
 	resp := dbplugin.InitializeResponse{
 		Config: req.Config,
 	}
-
 	return resp, nil
 }
 
@@ -86,12 +92,7 @@ func (m *MongoDBAtlas) NewUser(ctx context.Context, req dbplugin.NewUserRequest)
 		return dbplugin.NewUserResponse{}, err
 	}
 
-	username, err := credsutil.GenerateUsername(
-		credsutil.DisplayName("", credsutil.NoneLength),
-		credsutil.RoleName(req.UsernameConfig.RoleName, 15),
-		credsutil.MaxLength(20),
-		credsutil.Separator("-"),
-	)
+	username, err := m.usernameProducer.Generate(req.UsernameConfig)
 	if err != nil {
 		return dbplugin.NewUserResponse{}, err
 	}

--- a/mongodbatlas_test.go
+++ b/mongodbatlas_test.go
@@ -200,13 +200,11 @@ func TestAcceptanceDatabaseUser_CreateUserWithTemplate(t *testing.T) {
 	projectID := os.Getenv(envVarAtlasProjectID)
 	connURL := os.Getenv(envVarAtlasConnURL)
 
-	sep := "_"
-	usernameTemplate := "begin" + sep + "{{.RoleName}}" + sep + "end"
 	connectionDetails := map[string]interface{}{
 		"public_key":        publicKey,
 		"private_key":       privateKey,
 		"project_id":        projectID,
-		"username_template": usernameTemplate,
+		"username_template": "begin_{{.RoleName}}_end",
 	}
 
 	db := new()
@@ -236,7 +234,7 @@ func TestAcceptanceDatabaseUser_CreateUserWithTemplate(t *testing.T) {
 	defer deleteAtlasDBUser(t, projectID, publicKey, privateKey, createResp.Username)
 
 	assertCredsExists(t, projectID, publicKey, privateKey, createResp.Username, password, connURL, testMongoDBAtlasRole)
-	expectedUsername := "begin" + sep + roleName + sep + "end"
+	expectedUsername := "begin_" + roleName + "_end"
 	assertUsernameTemplate(t, createResp.Username, expectedUsername)
 }
 

--- a/mongodbatlas_test.go
+++ b/mongodbatlas_test.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"os"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/Sectorbob/mlab-ns2/gae/ns/digest"
 	dbplugin "github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 	dbtesting "github.com/hashicorp/vault/sdk/database/dbplugin/v5/testing"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -238,10 +238,8 @@ func TestAcceptanceDatabaseUser_CreateUserDefaultTemplate(t *testing.T) {
 		t.Fatalf("Username did not match template, username: %s, defaultUserNameTemplate: %s", createResp.Username, defaultUserNameTemplate)
 	}
 
-	expectedUsernamePrefix := "v-" + roleName + "-"
-	if !strings.HasPrefix(createResp.Username, expectedUsernamePrefix) {
-		t.Fatalf("Username did not match template, username: %s, defaultUserNameTemplate: %s", createResp.Username, defaultUserNameTemplate)
-	}
+	expectedUsernameRegex := `^v-test-[a-zA-Z0-9]{13}$`
+	require.Regexp(t, expectedUsernameRegex, createResp.Username)
 }
 
 func TestAcceptanceDatabaseUser_CreateUserWithTemplate(t *testing.T) {


### PR DESCRIPTION
# Overview
Adds the ability to customize username generation for dynamic users in MongoDB Atlas.

Uses the new field `username_template` with the [go template language](https://golang.org/pkg/text/template/).


# Contributor Checklist
- [x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
  - https://github.com/hashicorp/vault/pull/11943
- [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [x] Backwards compatible
