### PR TITLE
INTMDB217 - Wait until user is applied to clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,13 @@ go 1.12
 
 require (
 	github.com/Sectorbob/mlab-ns2 v0.0.0-20171030222938-d3aa0c295a8a
+	github.com/cenkalti/backoff/v4 v4.1.1
 	github.com/hashicorp/go-hclog v0.14.1
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.1
 	github.com/hashicorp/vault/sdk v0.2.0
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
 	github.com/mitchellh/mapstructure v1.3.2
 	github.com/stretchr/testify v1.7.0
-	go.mongodb.org/atlas v0.7.1
+	go.mongodb.org/atlas v0.10.1
 	go.mongodb.org/mongo-driver v1.4.2
 )

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/cenkalti/backoff/v4 v4.1.1 h1:G2HAfAmvm/GcKan2oOQpBXOd2tT2G57ZnZGWa1PxPBQ=
+github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
@@ -127,8 +129,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
-github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
@@ -313,8 +315,8 @@ github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c h1:u40Z8hqBAAQyv+vATcGgV
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v0.0.0-20180714160509-73f8eece6fdc h1:n+nNi93yXLkJvKwXNP9d55HC7lGK4H/SRcwB5IaUZLo=
 github.com/xdg/stringprep v0.0.0-20180714160509-73f8eece6fdc/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
-go.mongodb.org/atlas v0.7.1 h1:hNBtwtKgmhB9vmSX/JyN/cArmhzyy4ihKpmXSMIc4mw=
-go.mongodb.org/atlas v0.7.1/go.mod h1:CIaBeO8GLHhtYLw7xSSXsw7N90Z4MFY87Oy9qcPyuEs=
+go.mongodb.org/atlas v0.10.1 h1:IerzfJ7wqxJpaXen3jewg2+kUBnq2elMz2OPOz7Usas=
+go.mongodb.org/atlas v0.10.1/go.mod h1:MMWDsc2akjTDSG4tVQrxv/82p3QbBnqeELbtTl45sbg=
 go.mongodb.org/mongo-driver v1.4.2 h1:WlnEglfTg/PfPq4WXs2Vkl/5ICC6hoG8+r+LraPmGk4=
 go.mongodb.org/mongo-driver v1.4.2/go.mod h1:WcMNYLx/IlOxLe6JRJiv2uXuCz6zBLndR4SoGjYphSc=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=

--- a/mongodbatlas.go
+++ b/mongodbatlas.go
@@ -140,7 +140,6 @@ func (m *MongoDBAtlas) NewUser(ctx context.Context, req dbplugin.NewUserRequest)
 
 	var wg sync.WaitGroup
 	result := make(chan error, 10)
-	fmt.Printf("No. of clusters %d\n", len(clusterList))
 	wg.Add(len(clusterList))
 
 	for _, c := range clusterList {

--- a/mongodbatlas.go
+++ b/mongodbatlas.go
@@ -3,6 +3,7 @@ package mongodbatlas
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -86,7 +87,7 @@ func (m *MongoDBAtlas) NewUser(ctx context.Context, req dbplugin.NewUserRequest)
 		return dbplugin.NewUserResponse{}, dbutil.ErrEmptyCreationStatement
 	}
 	if len(req.Statements.Commands) > 1 {
-		return dbplugin.NewUserResponse{}, fmt.Errorf("only 1 creation statement supported for creation")
+		return dbplugin.NewUserResponse{}, errors.New("only 1 creation statement supported for creation")
 	}
 
 	client, err := m.getConnection(ctx)
@@ -112,7 +113,7 @@ func (m *MongoDBAtlas) NewUser(ctx context.Context, req dbplugin.NewUserRequest)
 	}
 
 	if len(databaseUser.Roles) == 0 {
-		return dbplugin.NewUserResponse{}, fmt.Errorf("roles array is required in creation statement")
+		return dbplugin.NewUserResponse{}, errors.New("roles array is required in creation statement")
 	}
 
 	databaseUserRequest := &mongodbatlas.DatabaseUser{
@@ -130,7 +131,7 @@ func (m *MongoDBAtlas) NewUser(ctx context.Context, req dbplugin.NewUserRequest)
 
 	clusters, _, err := client.Clusters.List(ctx, m.ProjectID, &mongodbatlas.ListOptions{})
 	if err != nil {
-		return dbplugin.NewUserResponse{}, fmt.Errorf("roles array is required in creation statement")
+		return dbplugin.NewUserResponse{}, errors.New("roles array is required in creation statement")
 	}
 
 	clusterList := []string{}
@@ -148,7 +149,7 @@ func (m *MongoDBAtlas) NewUser(ctx context.Context, req dbplugin.NewUserRequest)
 
 			operation := func() error {
 
-				status, _, err := client.Clusters.Status(context.Background(), m.ProjectID, clustername)
+				status, _, err := client.Clusters.Status(ctx, m.ProjectID, clustername)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
# Overview
As reported in the Vault repo issue: https://github.com/hashicorp/vault-plugin-database-mongodbatlas/issues/10
Right now the vault database user plugin for Atlas returns as soon as the API request is successfully accepted by Atlas. However the user takes time to apply to all the clusters in a project, meaning that if the credential is handed to an application that tries to then use that new credential right away- authentication fails. We now have an endpoint to check the status: https://docs.atlas.mongodb.com/reference/api/clusters-check-operation-status/
We need to build in the ability to poll that endpoint and wait to return the credential till it is really applied. Ideally this is an optional function so that if users would rather a faster return over being sure the user is really created we don't inadvertently frustrate them - if not possible then we'll default to the "really applied" default.

https://jira.mongodb.org/browse/INTMDB-217

# Design of Change
Create a goroutine for each of the clusters then wait until the change is applied on each of them. Wrap the errors and return error or the user if it's sucessfull. 

# Related Issues/Pull Requests
https://jira.mongodb.org/browse/INTMDB-217

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[x] Backwards compatible

No documentation is necessary at the time
