### PR TITLE
Replace usage of useragent.String with useragent.PluginString

### DIFF
--- a/connection_producer.go
+++ b/connection_producer.go
@@ -11,9 +11,18 @@ import (
 	dbplugin "github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 	"github.com/hashicorp/vault/sdk/database/helper/connutil"
 	"github.com/hashicorp/vault/sdk/helper/useragent"
+	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/mitchellh/mapstructure"
 	"github.com/mongodb-forks/digest"
 	"go.mongodb.org/atlas/mongodbatlas"
+)
+
+const (
+	// TODO: The Vault version used in the user agent string is hard coded until
+	//  it's possible for database plugins to use the system view to obtain correct
+	//  Vault version information via the plugin environment.
+	userAgentVaultVersion = "1.13.0"
+	userAgentPluginName   = "database-mongodbatlas"
 )
 
 type mongoDBAtlasConnectionProducer struct {
@@ -66,7 +75,12 @@ func (c *mongoDBAtlasConnectionProducer) Connection(_ context.Context) (interfac
 	if err != nil {
 		return nil, err
 	}
-	client.UserAgent = useragent.String()
+
+	// TODO: Obtain the plugin environment from the system view.
+	env := &logical.PluginEnvironment{
+		VaultVersion: userAgentVaultVersion,
+	}
+	client.UserAgent = useragent.PluginString(env, userAgentPluginName)
 
 	c.client = client
 


### PR DESCRIPTION
## Overview

This PR replaces usage of [`useragent.String`](https://github.com/hashicorp/vault/blob/main/sdk/helper/useragent/useragent.go#L43) with [`useragent.PluginString`](https://github.com/hashicorp/vault/blob/main/sdk/helper/useragent/useragent.go#L58). `useragent.String` has been deprecated. 

Note that there currently isn't a way for database plugins to obtain the plugin environment via Vault's system view. For now, we'll hard code the Vault version until we do the work to make it available. The Vault version information could already be inaccurate depending on how the plugin was running (builtin or external) and the SDK version it depended on. 

## Related Issues/Pull Requests

- https://github.com/hashicorp/vault/pull/14229
